### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,5 +1,8 @@
 name: Main pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]
@@ -36,6 +39,8 @@ jobs:
     runs-on: self-hosted
     needs: build
     if: github.event_name == 'push' && github.actor != 'github-actions[bot]'
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Trimax/ventaengine/security/code-scanning/2](https://github.com/Trimax/ventaengine/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. The best approach is to set the minimal required permissions at the workflow level (root), and then override them at the job level if a job needs more. In this case, set `permissions: contents: read` at the root, and for the `version-bump` job, set `permissions: contents: write` (since it pushes code). This ensures the `build` job only has read access, while `version-bump` has the write access it needs.

**What to change:**
- At the top level of `.github/workflows/maven.yml`, add:
  ```yaml
  permissions:
    contents: read
  ```
- Under the `version-bump` job, add:
  ```yaml
    permissions:
      contents: write
  ```
No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
